### PR TITLE
version is not defined in Magic Mirror 2.17

### DIFF
--- a/MMM-RBB-Weather.js
+++ b/MMM-RBB-Weather.js
@@ -213,11 +213,6 @@ Module.register('MMM-RBB-Weather', {
         if (temp >= 7) return 'fa-thermometer-quarter';
         if (temp >= 0) return 'fa-thermometer-empty';
 
-        // Font Awesome 5 (with fa-snowflake) is not available in MagicMirror < 2.6.0
-        if (version.localeCompare('2.6.0', 'en', { numeric: true }) < 0) {
-            return 'fa-asterisk';
-        }
-
         return 'fa-snowflake';
     },
 
@@ -232,12 +227,6 @@ Module.register('MMM-RBB-Weather', {
     getRainProbabilityIcon: function(prob) {
 
         if (prob <= 15) {
-
-            // Font Awesome 5 (with fa-tint-slash) is not available in MagicMirror < 2.6.0
-            if (version.localeCompare('2.6.0', 'en', { numeric: true }) < 0) {
-                return 'fa-tint dimmed';
-            }
-
             return 'fa-tint-slash';
         }
 

--- a/test/unit/MMM-RBB-Weather-Test.js
+++ b/test/unit/MMM-RBB-Weather-Test.js
@@ -12,8 +12,6 @@ describe('MMM-RBB-Weather', () => {
 
         module = newModule();
 
-        // Fake MagicMirror Version
-        version = '2.6.0';
     });
 
     afterEach(() => {
@@ -358,17 +356,6 @@ describe('MMM-RBB-Weather', () => {
             assert.deepStrictEqual(icon, 'fa-snowflake');
         });
 
-        it('should return "fa-asterisk" icon if temperature is lower than 0 and version is lower than 2.6.0', () => {
-
-            // Arrange
-            version = '2.5.99';
-
-            // Act
-            const icon = module.getTempIcon(-1);
-
-            // Assert
-            assert.deepStrictEqual(icon, 'fa-asterisk');
-        });
     });
 
     describe('getRainProbabilityIcon', () => {
@@ -389,18 +376,6 @@ describe('MMM-RBB-Weather', () => {
 
             // Assert
             assert.deepStrictEqual(icon, 'fa-tint-slash');
-        });
-
-        it('should return "fa-tint dimmed" icon if probability is under or equal low and version is lower than 2.6.0', () => {
-
-            // Arrange
-            version = '2.5.99';
-
-            // Act
-            const icon = module.getRainProbabilityIcon(15);
-
-            // Assert
-            assert.deepStrictEqual(icon, 'fa-tint dimmed');
         });
 
         it('should return "fa-umbrella" icon if probability is greater or equal high', () => {


### PR DESCRIPTION
should fix #51 by removing all version-related checks. This commit will drop support for Magic Mirror versions < 2.6 probably ...